### PR TITLE
Downgrade Prettier to version 2 to support VS Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-config-next": "^13.4.9",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-react": "^7.32.2",
-        "prettier": "^3.0.0"
+        "prettier": "2.8.8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3812,15 +3812,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "eslint-config-next": "^13.4.9",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-react": "^7.32.2",
-    "prettier": "^3.0.0"
+    "prettier": "2.8.8"
   }
 }


### PR DESCRIPTION
Prettier 3.0.0 is not yet supported in VS Code, so this downgrades the Prettier version to the latest v2 (2.8.8).

**Reference:** https://github.com/prettier/prettier/issues/14917#issuecomment-1585654226